### PR TITLE
support basic_radix2_domain internal FFT operations on group elements

### DIFF
--- a/libfqfft/evaluation_domain/domains/basic_radix2_domain_aux.hpp
+++ b/libfqfft/evaluation_domain/domains/basic_radix2_domain_aux.hpp
@@ -22,14 +22,14 @@ namespace libfqfft {
 /**
  * Compute the radix-2 FFT of the vector a over the set S={omega^{0},...,omega^{m-1}}.
  */
-template<typename FieldT>
-void _basic_radix2_FFT(std::vector<FieldT> &a, const FieldT &omega);
+template<typename FieldT, typename GroupT>
+void _basic_radix2_FFT(std::vector<GroupT> &a, const FieldT &omega);
 
 /**
  * A multi-thread version of _basic_radix2_FFT.
  */
-template<typename FieldT>
-void _parallel_basic_radix2_FFT(std::vector<FieldT> &a, const FieldT &omega);
+template<typename FieldT, typename GroupT>
+void _basic_parallel_radix2_FFT(std::vector<GroupT> &a, const FieldT &omega);
 
 /**
  * Translate the vector a to a coset defined by g.

--- a/libfqfft/evaluation_domain/evaluation_domain.hpp
+++ b/libfqfft/evaluation_domain/evaluation_domain.hpp
@@ -47,6 +47,11 @@ public:
     evaluation_domain(const size_t m) : m(m) {};
 
     /**
+     * Destructor must be virtual.
+     */
+    virtual ~evaluation_domain() = 0;
+
+    /**
      * Get the idx-th element in S.
      */
     virtual FieldT get_domain_element(const size_t idx) = 0;
@@ -97,6 +102,11 @@ public:
      */
     virtual void divide_by_Z_on_coset(std::vector<FieldT> &P) = 0;
 };
+
+template<typename FieldT>
+evaluation_domain<FieldT>::~evaluation_domain()
+{
+}
 
 } // libfqfft
 


### PR DESCRIPTION
Small change to support a second template parameter in FFT operations on `basic_radix2_domain`.